### PR TITLE
Fix when ci-depends-on is empty

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -150,7 +150,7 @@ jobs:
 
           # check if ci has a ci-depends-on 
           ci_ci_depends_on=$(echo "${{ inputs.ci-depends-on }}" | jq .ci)
-          if [ "$ci_ci_depends_on" != "null" ]; then
+          if [ -n "${{ inputs.ci-depends-on }}" ] && [ "$ci_ci_depends_on" != "null" ]; then
               echo "ci-depends-on for ci repository detected."
               ci_repo_url=$(echo "${{ inputs.ci-depends-on }}" | jq .ci.repo_url)
               ci_branch=$(echo "${{ inputs.ci-depends-on }}" | jq .ci.branch_name)


### PR DESCRIPTION




______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
